### PR TITLE
Fix election timer timeout.

### DIFF
--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -6,11 +6,13 @@ namespace raftcpp {
 
 class RaftcppConstants {
 public:
-    constexpr static uint64_t DEFAULT_ELECTION_TIMER_TIMEOUT_MS = 2000;
+    constexpr static uint64_t DEFAULT_ELECTION_TIMER_TIMEOUT_MS = 3000;
 
     constexpr static uint64_t DEFAULT_VOTE_TIMER_TIMEOUT_MS = 2000;
 
-    constexpr static uint64_t DEFAULT_HEARTBEAT_INTERVAL_MS = 3000;
+    /// Note that the heartbeat interval must be smaller than election timeout.
+    /// Otherwise followers will always request pre vote.
+    constexpr static uint64_t DEFAULT_HEARTBEAT_INTERVAL_MS = 2000;
 };
 
 }  // namespace raftcpp

--- a/src/common/timer.cc
+++ b/src/common/timer.cc
@@ -1,14 +1,39 @@
 #include "common/timer.h"
 
+#include <atomic>
+
 namespace raftcpp {
 namespace common {
 
-void RepeatedTimer::Reset(const uint64_t timeout_ms) {
+void RepeatedTimer::Start(const uint64_t timeout_ms) { Reset(timeout_ms); }
+
+void RepeatedTimer::Stop() {
     std::lock_guard<std::shared_mutex> guard{shared_mutex_};
-    is_running_ = true;
+    is_running_ = false;
+}
+
+void RepeatedTimer::Reset(const uint64_t timeout_ms) {
+    {
+        std::lock_guard<std::shared_mutex> guard{shared_mutex_};
+        is_running_ = true;
+    }
+    DoSetExpired(timeout_ms);
+}
+
+void RepeatedTimer::DoSetExpired(const uint64_t timeout_ms) {
+    std::shared_lock<std::shared_mutex> guard{shared_mutex_};
+    if (!is_running_) {
+        return;
+    }
+
     timer_.expires_from_now(std::chrono::milliseconds(timeout_ms));
     timer_.async_wait([this, timeout_ms](const asio::error_code &e) {
         {
+            if (e.value() == asio::error::operation_aborted) {
+                // The timer was canceled.
+                return;
+            }
+
             std::shared_lock<std::shared_mutex> guard{shared_mutex_};
             if (!is_running_) {
                 // The timer is stopping, should we should trigger any handler.
@@ -16,13 +41,8 @@ void RepeatedTimer::Reset(const uint64_t timeout_ms) {
             }
         }
         timeout_handler_(e);
-        this->Reset(timeout_ms);
+        this->DoSetExpired(timeout_ms);
     });
-}
-
-void RepeatedTimer::Stop() {
-    std::lock_guard<std::shared_mutex> guard{shared_mutex_};
-    is_running_ = false;
 }
 
 }  // namespace common

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -31,11 +31,14 @@ public:
           timer_(io_service_),
           timeout_handler_(std::move(timeout_handler)) {}
 
-    void Start(const uint64_t timeout_ms) { Reset(timeout_ms); }
+    void Start(const uint64_t timeout_ms);
+
+    void Stop();
 
     void Reset(const uint64_t timeout_ms);
 
-    void Stop();
+private:
+    void DoSetExpired(const uint64_t timeout_ms);
 
 private:
     // The io service that runs this timer.

--- a/src/node/node.h
+++ b/src/node/node.h
@@ -73,19 +73,20 @@ private:
     // request.
     std::unordered_set<std::string> responded_vote_nodes_;
 
-    // The mutex that protects all of the node state.
-    std::mutex mutex_;
+    // The recursive mutex that protects all of the node state.
+    std::recursive_mutex mutex_;
 
-    // The io service that is used to run some methods which is needed a separated
-    // service.
-    asio::io_service io_service_;
-
-    // The work runs on the io_service_, to make sure the io_service_ doesn't stop once
-    // there is no any pending task.
-    asio::io_service::work work_;
-
-    // The thread that runs the io_service above.
-    std::thread io_service_thread_;
+    //    // The io service that is used to run some methods which is needed a separated
+    //    // service.
+    //    asio::io_service io_service_;
+    //
+    //    // The work runs on the io_service_, to make sure the io_service_ doesn't stop
+    //    once
+    //    // there is no any pending task.
+    //    asio::io_service::work work_;
+    //
+    //    // The thread that runs the io_service above.
+    //    std::thread io_service_thread_;
 };
 
 }  // namespace node

--- a/src/node/timer_manager.cc
+++ b/src/node/timer_manager.cc
@@ -10,7 +10,7 @@ TimerManager::TimerManager(const std::function<void()> &election_timer_timeout_h
                            const std::function<void()> &heartbeat_timer_timeout_handler,
                            const std::function<void()> &vote_timer_timeout_handler) {
     io_service_ = std::make_unique<asio::io_service>();
-
+    work_ = std::make_unique<asio::io_service::work>(*io_service_);
     election_timer_ = std::make_unique<common::RepeatedTimer>(
         *io_service_, [election_timer_timeout_handler](const asio::error_code &e) {
             if (e.value() != asio::error::operation_aborted) {

--- a/src/node/timer_manager.h
+++ b/src/node/timer_manager.h
@@ -33,6 +33,8 @@ private:
     // A separated service that runs for all timers.
     std::unique_ptr<asio::io_service> io_service_ = nullptr;
 
+    std::unique_ptr<asio::io_service::work> work_ = nullptr;
+
     // The thread that runs all timers.
     std::unique_ptr<std::thread> thread_ = nullptr;
 


### PR DESCRIPTION
This PR fix the following issues:
1. `DEFAULT_HEARTBEAT_INTERVAL_MS` must smaller than `DEFAULT_HEARTBEAT_INTERVAL_MS `.
2. Use `std::recursive_mutex` instead of mutex.
3. Add a case to test the `RepeatedTimer::Reset()`.
